### PR TITLE
[Fix] Skip APIPA network

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -54,6 +54,11 @@ def scanNetwork():
         if netmask <= 0 or netmask == 0xFFFFFFFF:
             continue
 
+        # Skip APIPA network (corresponds to the 169.254.0.0/16 adress range)
+        # See https://fr.wikipedia.org/wiki/Automatic_Private_Internet_Protocol_Addressing for more details
+        if network == 2851995648:
+            continue
+
         net = to_CIDR_notation(network, netmask)
 
         if interface != scapy.config.conf.iface:


### PR DESCRIPTION
I had an issue in the scan.py file.
During the for loop iterating over all the routes, the network address of my en0 wifi interface is wrong. Indeed, the ouput of "to_CIDR_notation" is "169.254.0.0/16" even though the correct network is "172.24.0.0/16".

This is because of [APIPA](https://fr.wikipedia.org/wiki/Automatic_Private_Internet_Protocol_Addressing) protocol that creates a temporary network during DHCP, and this network interfers with the for loop.
 
Here is a picture of the output of scapy.config.conf.route that explains it 
![screen shot 2017-01-17 at 11 28 15](https://cloud.githubusercontent.com/assets/7913565/22016878/1f7bc21c-dca8-11e6-957d-2929f02c316e.png)

I just added a condition to skip this network.