### PR TITLE
Fix ValueError #284

### DIFF
--- a/kickthemout.py
+++ b/kickthemout.py
@@ -151,7 +151,7 @@ def getDefaultInterface(returnNet=False):
         return net
 
     iface_routes = [route for route in scapy.config.conf.route.routes if route[3] == scapy.config.conf.iface and route[1] != 0xFFFFFFFF]
-    network, netmask, _, interface, address = max(iface_routes, key=lambda item:item[1])
+    network, netmask, _, interface, address, _ = max(iface_routes, key=lambda item:item[1])
     net = to_CIDR_notation(network, netmask)
     if net:
         if returnNet:

--- a/kickthemout.py
+++ b/kickthemout.py
@@ -151,7 +151,11 @@ def getDefaultInterface(returnNet=False):
         return net
 
     iface_routes = [route for route in scapy.config.conf.route.routes if route[3] == scapy.config.conf.iface and route[1] != 0xFFFFFFFF]
-    network, netmask, _, interface, address, _ = max(iface_routes, key=lambda item:item[1])
+    try:
+        network, netmask, _, interface, address = max(iface_routes, key=lambda item:item[1])
+    except:
+        network, netmask, _, interface, address, _ = max(iface_routes, key=lambda item:item[1])
+    
     net = to_CIDR_notation(network, netmask)
     if net:
         if returnNet:


### PR DESCRIPTION
This is a fix for the issue #284.

Scapy return a new tuple for routes : (dst_int, msk_int, gw_str, iff, ifaddr, metric), so fix the code.